### PR TITLE
Removed extra formatting

### DIFF
--- a/src/BuildVision.UI/Helpers/BuildMessages.cs
+++ b/src/BuildVision.UI/Helpers/BuildMessages.cs
@@ -277,8 +277,7 @@ namespace BuildVision.UI.Helpers
                 return string.Empty;
 
             TimeSpan timeSpan = buildInfo.BuildFinishTime.Value.Subtract(buildInfo.BuildStartTime.Value);
-            string extraTimePartString = GetExtraTimePartString(labelsSettings, timeSpan);
-            return string.Format(labelsSettings.ExtraMessageStringFormat, extraTimePartString);
+            return GetExtraTimePartString(labelsSettings, timeSpan);
         }
 
         private static string GetExtraTimePartString(BuildMessagesSettings labelsSettings, TimeSpan timeSpan)


### PR DESCRIPTION
Extra formatting causes text like this:
> Build solution 'Foo' completed successfully at 1:23:45 ( (01:23))

Notice extra parentheses around elapsed time.
No big deal, but it is somewhat annoying. :)

P.S. this extension is pure AWESOMENESS!