### PR TITLE
Reduced retained logs size

### DIFF
--- a/src/BuildVision.Common/Logging/LogManager.cs
+++ b/src/BuildVision.Common/Logging/LogManager.cs
@@ -34,9 +34,12 @@ namespace BuildVision.Common.Logging
                     .Enrich.WithThreadId()
                     .MinimumLevel.ControlledBy(LoggingLevelSwitch)
                     .WriteTo.File(logPath,
-                        fileSizeLimitBytes: null,
                         outputTemplate: outputTemplate,
-                        shared: true)
+                        shared: true,
+                        fileSizeLimitBytes: 10 * 1024 * 1024,
+                        rollOnFileSizeLimit: true,
+                        retainedFileCountLimit: 10,
+                        rollingInterval: RollingInterval.Day)
                     .CreateLogger();
             }
             catch(Exception ex)


### PR DESCRIPTION
I propose a simple Serilog configuration change to reduce the retained log file size.